### PR TITLE
Retry _configure_option to fix IOError caused by not-ready sys files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 twisted
+retry

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     version=txgpio.__version__,
     description='Twisted-based asynchronous library for using GPIO.',
     packages=find_packages(),
-    install_requires=['twisted'],
+    install_requires=['twisted', 'retry'],
     py_modules=['txgpio'],
     license="MIT",
 )

--- a/txgpio/sysfs.py
+++ b/txgpio/sysfs.py
@@ -1,5 +1,6 @@
 import os.path
 import platform
+from retry import retry
 from twisted.python import log
 try:
     platform.linux_distribution()
@@ -102,6 +103,7 @@ class GPIO(abstract.FileDescriptor, object):
         gpio_value_path = os.path.join(self.sysfs_gpio_node_dir, 'value')
         return open(gpio_value_path, mode)
 
+    @retry(IOError, tries=3, delay=0.02, backoff=5)
     def _configure_option(self, gpio_dir, variable, value, options):
         if value is not None:
             value = value.lower()


### PR DESCRIPTION
Address #1 by retrying _configure_option 3 times before aborting.
If it fails first time, try again after 20 ms, then again after 5*20ms = 100 ms.